### PR TITLE
Fixed compilation error due to missing braces

### DIFF
--- a/source/cur.cpp
+++ b/source/cur.cpp
@@ -1,33 +1,23 @@
 
-#include"../include/cur.hpp"
-#include<cstdio>
-#include<cstdlib>
+#include "../include/cur.hpp"
+#include <cstdio>
+#include <cstdlib>
 //cursor related ,see cur.h for more documentation
-void Cur::moveCur(const int x,const int y) //moving the cursor ,const for safety 
+void Cur::moveCur(const int x, const int y) //moving the cursor ,const for safety
 {
 	int i;
-	for(i = 0; i < y; i++)
+	for (i = 0; i < y; i++)
 		printf("\33[2C"); //works for x axis line 10
-	for(i = 0; i < x; i++)
+	for (i = 0; i < x; i++)
 		printf("\33[1B"); //works for y axis line 11
+}
+
 void Cur::saveCur()
 {
 	//save cur and move to destination
-	printf("\33[s");	
+	printf("\33[s");
 }
 void Cur::resumeCur()
 {
 	printf("\33[u");
 }
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
### Issue
The project failed to compile due to missing closing braces in `source/cur.cpp`. The PR fixes #1.

### Fix
Add a closing brace at line 13 of `source/cur.cpp`.

### Testing
The project builds successfully after the fix.